### PR TITLE
Moving to correct directories in startup

### DIFF
--- a/mnemosyne.run.j2
+++ b/mnemosyne.run.j2
@@ -17,7 +17,7 @@ then
     CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions'
 
     # Change into the HPFeeds dir, it's needed for hpfeeds scripts
-    pushd  {{ hpfeeds_dir }}/hpfeeds/broker/
+    pushd {{ hpfeeds_dir }}/hpfeeds/broker/
 
     # Generate config file for hpfeeds broker and try to register
     # Exit if failed, and try again
@@ -35,7 +35,7 @@ then
 
     # Change back to Mnemosyne dir
     popd
-    
+
     cp ./mnemosyne.cfg.template ./mnemosyne.cfg
 
     sed -i "s/ident *=.*/ident = ${IDENT}/" {{ mnemosyne_dir }}/mnemosyne.cfg

--- a/mnemosyne.run.j2
+++ b/mnemosyne.run.j2
@@ -17,7 +17,7 @@ then
     CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions'
 
     # Change into the HPFeeds dir, it's needed for hpfeeds scripts
-    pushd {{ hpfeeds_dir }}
+    pushd  {{ hpfeeds_dir }}/hpfeeds/broker/
 
     # Generate config file for hpfeeds broker and try to register
     # Exit if failed, and try again

--- a/mnemosyne.run.j2
+++ b/mnemosyne.run.j2
@@ -16,6 +16,9 @@ then
     SECRET=`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`
     CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions'
 
+    # Change into the HPFeeds dir, it's needed for hpfeeds scripts
+    pushd {{ hpfeeds_dir }}
+
     # Generate config file for hpfeeds broker and try to register
     # Exit if failed, and try again
     python {{ hpfeeds_dir }}/hpfeeds/broker/generateconfig.py unattended \
@@ -29,6 +32,9 @@ then
         "${SECRET}" \
         "" \
         "${CHANNELS}" || exit 1
+
+    # Change back to Mnemosyne dir
+    popd
     
     cp ./mnemosyne.cfg.template ./mnemosyne.cfg
 


### PR DESCRIPTION
Turns out dependent scripts for hpfeeds require being in that directory to execute.  Added a pushd and popd to move around correctly during the startup.