### PR TITLE
Allow removal of mongo docs after x secs

### DIFF
--- a/mnemosyne.cfg.template
+++ b/mnemosyne.cfg.template
@@ -7,6 +7,7 @@ port = 8181
 mongo_host = localhost
 mongo_port = 27017
 database = mnemosyne
+mongo_indexttl = 
 
 [hpfriends]
 ident =

--- a/mnemosyne.run.j2
+++ b/mnemosyne.run.j2
@@ -45,6 +45,9 @@ then
     sed -i "s/channels *=.*/channels = ${CHANNELS}/" {{ mnemosyne_dir }}/mnemosyne.cfg
     sed -i "s/mongo_host *=.*/mongo_host = ${MONGODB_HOST}/" {{ mnemosyne_dir }}/mnemosyne.cfg
     sed -i "s/mongo_port *=.*/mongo_port = ${MONGODB_PORT}/" {{ mnemosyne_dir }}/mnemosyne.cfg
+    if [[ ! -z "${MONGODB_INDEXTTL}" ]]; then
+      sed -i "s/mongo_indexttl *=.*/mongo_indexttl = ${MONGODB_INDEXTTL}/" {{ mnemosyne_dir }}/mnemosyne.cfg
+    fi
     sed -i "s/ignore_rfc1918 *=.*/ignore_rfc1918 = ${IGNORE_RFC1918}/" {{ mnemosyne_dir }}/mnemosyne.cfg
 
 fi

--- a/mnemosyne/runner.py
+++ b/mnemosyne/runner.py
@@ -58,6 +58,11 @@ def parse_config(config_file):
     config['mongo_host'] = parser.get('mongodb', 'mongo_host')
     config['mongo_port'] = parser.getint('mongodb', 'mongo_port')
     config['mongo_db'] = parser.get('mongodb', 'database')
+    try:
+        config['mongo_indexttl'] = parser.getint('mongodb', 'mongo_indexttl')
+    except ValueError:
+        # if no value set or not an int, just set to False
+        config['mongo_indexttl'] = False 
 
     config['hpf_feeds'] = parser.get('hpfriends', 'channels').split(',')
     config['hpf_ident'] = parser.get('hpfriends', 'ident')
@@ -116,7 +121,7 @@ if __name__ == '__main__':
     greenlets = {}
 
     db = mnemodb.MnemoDB(host=c['mongo_host'], port=c['mongo_port'],
-                         database_name=c['mongo_db'])
+                         database_name=c['mongo_db'], indexttl=c['mongo_indexttl'])
 
     webapi = None
     hpfriends_puller = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymongo==2.7.2
+pymongo==2.8.1
 gevent==1.0.2
 bottle-mongodb==0.2.1
 bottle-cork==0.6


### PR DESCRIPTION
Allows for the creation of an environment variable in the mnemosyne container called **MONGODB_INDEXTTL** whose values is an integer in seconds. This value is used to compare against the _timestamp_ field of the **session** and **hpfeed** collections in the **mnemosyne** db and remove documents whose _timestamp_ fields are older than the number of seconds between now() and the **MONGODB_INDEXTTL** value.. 

Mongo's built-in TTL Index worker takes care of the expired documents, decreasing the size of the database (source: https://docs.mongodb.com/manual/core/index-ttl/)

For example, if one wants to remove mongo documents after 30 days, the **MONGODB_INDEXTTL** env variable can be set to `2592000` (30 days * 24 hours * 60 mins * 60 seconds).

This can easily be added to the docker-compose file under the services--> mnemosyne section like so:

```
services:

  mongodb:

    image: stingar/mongodb:1.8

    volumes:

      - ./storage/mongodb:/var/lib/mongo:z

  redis:

    image: stingar/redis:1.8

    volumes:

      - ./storage/redis:/var/lib/redis:z

  hpfeeds:

    image: stingar/hpfeeds:1.8

    links:

      - mongodb:mongodb

    ports:

      - "10000:10000"

  mnemosyne:

    image: stingar/mnemosyne:1.8

    links:

      - mongodb:mongodb

      - hpfeeds:hpfeeds

    environment:

      - MONGODB_INDEXTTL=2592000 # 60 sec * 60 min * 24 hrs * 30 days

```

Had to update the pymongo version slightly to fix a bug in some of the functions I was trying to use like index_information().

Tested in a dev env going from no defined **MONGODB_INDEXTTL** value to a number, to a different number, back to nothing (with container downs/ups between). All seems to work okay so far.